### PR TITLE
Fix speeddial-spacing.js to work with 3.8

### DIFF
--- a/vivaldi/hooks/speeddial-spacing.js
+++ b/vivaldi/hooks/speeddial-spacing.js
@@ -35,7 +35,7 @@ vivaldi.jdhooks.hookClass('speeddial_SpeedDialView', cls => {
                 const spacing = sets.spacing
 
                 let count = this.state.dialNodes.length
-                // One more for the ‘plus’ tile
+                // One more for the "plus" tile
                 if (this.props.prefValues[PrefKeys.kStartpageSpeedDialAddButtonVisible]) count++
 
                 const spacedWidth = width + 2 * spacing
@@ -44,7 +44,7 @@ vivaldi.jdhooks.hookClass('speeddial_SpeedDialView', cls => {
                 let bgHeight = height
                 // Add space for titles
                 const showTitle = this.props.prefValues[PrefKeys.kStartpageSpeedDialTitlesAndFaviconVisible || PrefKeys.kStartpageSpeedDialTitlesVisible]
-                if (showTitle !== "never") {
+                if (showTitle === "always") {
                     spacedHeight += 32
                     bgHeight += 32
                 }

--- a/vivaldi/hooks/speeddial-spacing.js
+++ b/vivaldi/hooks/speeddial-spacing.js
@@ -22,8 +22,6 @@ vivaldi.jdhooks.hookClass('speeddial_SpeedDialView', cls => {
         constructor(...e) {
             super(...e)
 
-            // To get the original code, search for getSpeedDialGeometry, it’s
-            // just a few matches
             this.getSpeedDialGeometry = () => {
                 const sets = this.state.jdVivaldiSettings.SPEEDDIAL_SIZING
 
@@ -43,9 +41,13 @@ vivaldi.jdhooks.hookClass('speeddial_SpeedDialView', cls => {
                 const spacedWidth = width + 2 * spacing
 
                 let spacedHeight = height + 2 * spacing
+                let bgHeight = height
                 // Add space for titles
-                if (this.props.prefValues[PrefKeys.kStartpageSpeedDialTitlesVisible] !== "never")
-                    spacedHeight += 30
+                const showTitle = this.props.prefValues[PrefKeys.kStartpageSpeedDialTitlesAndFaviconVisible || PrefKeys.kStartpageSpeedDialTitlesVisible]
+                if (showTitle !== "never") {
+                    spacedHeight += 32
+                    bgHeight += 32
+                }
 
                 const margin = sets.edgeMargin
                 const maxCols = this.props.prefValues[PrefKeys.kStartpageSpeedDialColumns] || 1000
@@ -61,6 +63,8 @@ vivaldi.jdhooks.hookClass('speeddial_SpeedDialView', cls => {
                     cols = 1
 
                 return {
+                    backgroundWidth: width,
+                    backgroundHeight: bgHeight,
                     count: count,
                     cols: cols,
                     rows: Math.ceil(count / cols),

--- a/vivaldi/hooks/speeddial-spacing.js
+++ b/vivaldi/hooks/speeddial-spacing.js
@@ -43,7 +43,7 @@ vivaldi.jdhooks.hookClass('speeddial_SpeedDialView', cls => {
                 let spacedHeight = height + 2 * spacing
                 let bgHeight = height
                 // Add space for titles
-                const showTitle = this.props.prefValues[PrefKeys.kStartpageSpeedDialTitlesAndFaviconVisible || PrefKeys.kStartpageSpeedDialTitlesVisible]
+                const showTitle = this.props.prefValues[PrefKeys.kStartpageSpeedDialTitlesVisible]
                 if (showTitle === "always") {
                     spacedHeight += 32
                     bgHeight += 32


### PR DESCRIPTION
I didn’t check it personally now, but last time they made visible changes it worked, & @Pathduck said it still works.

It should be compatible with the 3.6 speed dial.