### PR TITLE
Adjust multine-tabs CSS to support Vivaldi 7.0

### DIFF
--- a/vivaldi/hooks/multiline-tabs.css
+++ b/vivaldi/hooks/multiline-tabs.css
@@ -32,6 +32,14 @@
   width: auto !important;
   transform: inherit !important;
 }
+#browser.tabs-bottom .tab-strip > span > .tab-position > .tab,
+#browser.tabs-top .tab-strip > span > .tab-position > .tab {
+  max-width: unset !important;
+}
+#browser.tabs-bottom .tab-strip > span > .tab-position > .tab.active,
+#browser.tabs-top .tab-strip > span > .tab-position > .tab.active {
+  height: unset !important;
+}
 #browser.tabs-bottom .tab-strip > span > .tab-position > .tab:not(.pinned),
 #browser.tabs-top .tab-strip > span > .tab-position > .tab:not(.pinned) {
   width: 220px !important;
@@ -39,6 +47,10 @@
 #browser.tabs-bottom .tab-strip > span > .tab-position > .tab.pinned,
 #browser.tabs-top .tab-strip > span > .tab-position > .tab.pinned {
   width: 30px !important;
+}
+#browser.tabs-bottom .tab-strip > span > .tab-position .tab-header,
+#browser.tabs-top .tab-strip > span > .tab-position .tab-header {
+  max-width: unset !important;
 }
 #browser.tabs-bottom .tab-strip > span > .tab-position .tab-header > .favicon > svg,
 #browser.tabs-top .tab-strip > span > .tab-position .tab-header > .favicon > svg {


### PR DESCRIPTION
Added new CSS rules to account for new Vivaldi styles that made the multi-line tabs CSS modification stop working.
